### PR TITLE
ページが左のナビゲーションに出現するように変更

### DIFF
--- a/content/pages/_index.md
+++ b/content/pages/_index.md
@@ -1,3 +1,3 @@
 ---
-bookHidden: true
+title: "記事"
 ---


### PR DESCRIPTION
`/content/pages/_index.md` で、`bookHidden: true` に設定されており、 ページ一覧が表示されないため、該当パラメタを削除した。
それによって、左のナビゲーションに記事が出現するようになった。

また、タイトルは「記事」とした。
さらにふさわしい名前がある場合はコメントをお願いします。

![image](https://user-images.githubusercontent.com/37617413/232329469-cf65344f-33a7-45ef-aec1-6b8e969bc491.png)
